### PR TITLE
App name with symbols

### DIFF
--- a/faag_cli/core/app_generator.py
+++ b/faag_cli/core/app_generator.py
@@ -18,9 +18,10 @@ class AppGenerator:
                 "[bold green]🛠 Generating flask app is currently under development. Coming soon...[/bold green]"
             )
             sys.exit(1)
+        validated_app_name: str = FaagUtils.validate_app_name(app_name)
         os.mkdir("app")
         app_template = templates_environment.get_template(f"{app_type}__init__.jinja")
-        app_template_rendered = app_template.render(app_name=app_name)
+        app_template_rendered = app_template.render(app_name=validated_app_name)
         with open("app/__init__.py", "w", encoding="UTF-8") as fast_api_init:
             fast_api_init.write(app_template_rendered)
 

--- a/faag_cli/templates/fast__init__.jinja
+++ b/faag_cli/templates/fast__init__.jinja
@@ -3,7 +3,7 @@ from starlette import status
 from starlette.middleware.cors import CORSMiddleware
 from starlette.responses import JSONResponse
 
-from app.config import Constants, Events
+from app.config import Constants
 from app.config.app_config import AppConfig, generate_settings
 from app.controller import private_fast_app
 from app.schemas import CommonResponseSchema
@@ -21,7 +21,6 @@ def create_fast_app() -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
-    base_app.add_event_handler("startup", events.create_start_app_handler())
     return base_app
 
 

--- a/faag_cli/utils/faag_utils.py
+++ b/faag_cli/utils/faag_utils.py
@@ -1,5 +1,8 @@
 import os
+import re
 import sys
+from re import Pattern
+
 from rich import print as rprint
 
 from faag_cli.utils.templates_loader import templates_environment
@@ -20,3 +23,18 @@ class FaagUtils:
                 "[bold red]:police_car_light:Error: App already exists. Please delete the app folder and try again[/bold red]"
             )
             sys.exit(1)
+
+    @staticmethod
+    def validate_app_name(app_name: str) -> str:
+        app_name_pattern: Pattern = re.compile(r".*[@!#$%^&*()<>?/\|}{~:].*")
+        if app_name_pattern.match(app_name):
+            rprint(
+                "[bold red]:police_car_light:Error: App name should not contain special characters[/bold red]"
+            )
+            sys.exit(1)
+        if app_name[0].isdigit():
+            rprint(
+                "[bold red]:police_car_light:Error: App name should not start with a number[/bold red]"
+            )
+            sys.exit(1)
+        return app_name.replace("-", "_")


### PR DESCRIPTION
Added functionality to avoid errors in app_name. This will resolve issue #7.

Now app name provided with special symbols will throw an error and `-` will be converted to `_`.

For example:

```python
faag --app-name fast-app
```

Here `fast-app` will be changed to `fast_app`