### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Code Formatting and Linting
+permissions:
+    contents: read
 
 on:
     push:


### PR DESCRIPTION
Potential fix for [https://github.com/pythonhubdev/faag_cli/security/code-scanning/1](https://github.com/pythonhubdev/faag_cli/security/code-scanning/1)

To fix the problem, explicitly set the permissions in the workflow or at the job level. Since the workflow only checks out code, installs Python dependencies, and runs linting, formatting, type-checking, and so forth—all operations that only require reading the repository—it's sufficient and safest to add a `permissions: contents: read` block at the workflow level. This will ensure the minimal required permissions are used for all jobs in the workflow.

The change should be made by inserting the following block near the top of `.github/workflows/ci.yml`, after the `name` key and before the `on:` key:

```yaml
permissions:
  contents: read
```

No new imports or other file-level changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
